### PR TITLE
feat(sensor-service): add mqtt ingestion, data cleaning (test/clamp),…

### DIFF
--- a/backend-SpringBoot/BabyGuardianBackend/sensor-service/pom.xml
+++ b/backend-SpringBoot/BabyGuardianBackend/sensor-service/pom.xml
@@ -117,6 +117,12 @@
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         </dependency>
 
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-stream-kafka</artifactId>
+        </dependency>
+
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/SensorServiceApplication.java
+++ b/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/SensorServiceApplication.java
@@ -1,12 +1,15 @@
 package org.babyguardianbackend.sensorservice;
 
+import org.babyguardianbackend.sensorservice.cleaning.CleaningProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableConfigurationProperties(CleaningProperties.class)
 @EnableScheduling
 public class SensorServiceApplication {
 

--- a/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/cleaning/CleaningProperties.java
+++ b/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/cleaning/CleaningProperties.java
@@ -1,0 +1,22 @@
+package org.babyguardianbackend.sensorservice.cleaning;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "app.cleaning")
+public class CleaningProperties {
+
+    // correspond à app.cleaning.tempMin etc.
+    private double tempMin = 34.0;
+    private double tempMax = 42.0;
+
+    private int hrMin = 60;
+    private int hrMax = 220;
+
+    private int spo2Min = 70;
+    private int spo2Max = 100;
+
+    // REJECT | CLAMP | TEST
+    private String mode = "REJECT";
+}

--- a/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/cleaning/DataCleaningService.java
+++ b/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/cleaning/DataCleaningService.java
@@ -1,0 +1,76 @@
+package org.babyguardianbackend.sensorservice.cleaning;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DataCleaningService {
+
+    private final CleaningProperties p;
+
+    public VitalClean cleanOrThrow(VitalRaw raw, String fallbackDeviceId) {
+
+        String deviceId = (raw.deviceId() != null && !raw.deviceId().isBlank())
+                ? raw.deviceId()
+                : fallbackDeviceId;
+
+        long ts = (raw.timestamp() != null) ? raw.timestamp() : System.currentTimeMillis();
+
+        if (raw.temperature() == null || raw.spo2() == null || raw.heartRate() == null) {
+            throw new IllegalArgumentException("Missing fields");
+        }
+
+        double temp = raw.temperature();
+        double spo2 = raw.spo2();
+        double hr   = raw.heartRate();
+
+        // Fahrenheit -> Celsius (si besoin)
+        if (temp > 60) temp = (temp - 32) * (5.0 / 9.0);
+
+        // ✅ MODE TEST : accepte tout (pas de validation)
+        if ("TEST".equalsIgnoreCase(p.getMode())) {
+            return new VitalClean(
+                    deviceId,
+                    temp,
+                    (int) Math.round(spo2),
+                    (int) Math.round(hr),
+                    ts,
+                    "TEST"
+            );
+        }
+
+        boolean clamped = false;
+
+        if ("CLAMP".equalsIgnoreCase(p.getMode())) {
+
+            double newTemp = clamp(temp, p.getTempMin(), p.getTempMax());
+            double newSpo2 = clamp(spo2, p.getSpo2Min(), p.getSpo2Max());
+            double newHr   = clamp(hr,   p.getHrMin(),   p.getHrMax());
+
+            clamped = (newTemp != temp) || (newSpo2 != spo2) || (newHr != hr);
+
+            temp = newTemp;
+            spo2 = newSpo2;
+            hr = newHr;
+
+        } else { // REJECT
+            if (temp < p.getTempMin() || temp > p.getTempMax()) throw new IllegalArgumentException("temp invalid");
+            if (spo2 < p.getSpo2Min() || spo2 > p.getSpo2Max()) throw new IllegalArgumentException("spo2 invalid");
+            if (hr < p.getHrMin() || hr > p.getHrMax()) throw new IllegalArgumentException("hr invalid");
+        }
+
+        return new VitalClean(
+                deviceId,
+                temp,
+                (int) Math.round(spo2),
+                (int) Math.round(hr),
+                ts,
+                clamped ? "CLAMPED" : "OK"
+        );
+    }
+
+    private double clamp(double v, double min, double max) {
+        return Math.max(min, Math.min(max, v));
+    }
+}

--- a/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/cleaning/VitalClean.java
+++ b/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/cleaning/VitalClean.java
@@ -1,0 +1,12 @@
+package org.babyguardianbackend.sensorservice.cleaning;
+
+// cleaning/VitalClean.java
+public record VitalClean(
+        String deviceId,
+        double temperatureC,
+        int spo2,
+        int heartRate,
+        long timestamp,
+        String quality // OK | CLAMPED
+) {}
+

--- a/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/cleaning/VitalRaw.java
+++ b/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/cleaning/VitalRaw.java
@@ -1,0 +1,11 @@
+package org.babyguardianbackend.sensorservice.cleaning;
+
+// cleaning/VitalRaw.java
+public record VitalRaw(
+        String deviceId,
+        Double temperature,
+        Double spo2,
+        Double heartRate,
+        Long timestamp
+) {}
+

--- a/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/controller/TestKafka.java
+++ b/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/controller/TestKafka.java
@@ -1,0 +1,19 @@
+package org.babyguardianbackend.sensorservice.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.babyguardianbackend.sensorservice.service.VitalsProducer;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TestKafka {
+//    private final VitalsProducer vitalsProducer;
+//    @PostMapping("/publish")
+//    public String publish(@RequestParam String topic, @RequestBody String payload) {
+//    vitalsProducer.sendCleanVitals("test",topic, payload);
+//    return "ok";
+//    }
+}

--- a/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/mqttConfig/MqttConfig.java
+++ b/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/mqttConfig/MqttConfig.java
@@ -80,9 +80,20 @@ public class MqttConfig {
 
     @Bean
     @ServiceActivator(inputChannel = "mqttOutboundChannel")
-    public MessageHandler mqttOutbound(MqttPahoClientFactory factory) {
-        MqttPahoMessageHandler handler = new MqttPahoMessageHandler("spring-publisher", factory);
+    public MessageHandler mqttOutbound(
+            MqttPahoClientFactory factory,
+            @Value("${app.mqtt.publisherClientId:spring-publisher-${random.value}}") String pubClientId,
+            @Value("${app.mqtt.qos:1}") int qos,
+            @Value("${app.mqtt.defaultPublishTopic:iot/alerts/default}") String defaultTopic
+    ) {
+        MqttPahoMessageHandler handler = new MqttPahoMessageHandler(pubClientId, factory);
         handler.setAsync(true);
+
+        // Si tu oublies TOPIC dans le header, il publiera sur ce topic par défaut
+        handler.setDefaultTopic(defaultTopic);
+        handler.setDefaultQos(qos);
+
         return handler;
     }
+
 }

--- a/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/securityConfig/SecurityConfig.java
+++ b/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/securityConfig/SecurityConfig.java
@@ -1,4 +1,4 @@
-package org.babyguardianbackend.sensorservice.config;
+package org.babyguardianbackend.sensorservice.securityConfig;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,8 +7,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-public class SecurityConfig {
-    @Bean
+public class SecurityConfig {    @Bean
     public SecurityFilterChain api(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())

--- a/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/service/VitalsProducer.java
+++ b/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/java/org/babyguardianbackend/sensorservice/service/VitalsProducer.java
@@ -1,0 +1,29 @@
+package org.babyguardianbackend.sensorservice.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.babyguardianbackend.sensorservice.cleaning.VitalClean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VitalsProducer {
+
+    private final ObjectMapper om;
+    private final KafkaTemplate<String, String> kafka;
+
+    @Value("${app.kafka.topic.vitalsCleaned:iot.vitals.cleaned}")
+    private String vitalsCleanedTopic;
+
+    public void sendCleanVitals(String deviceId, VitalClean vitalClean) {
+        try {
+            String json = om.writeValueAsString(vitalClean);
+            kafka.send(vitalsCleanedTopic, deviceId, json); // key=deviceId ✅
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize VitalClean to JSON", e);
+        }
+    }
+}

--- a/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/resources/application.properties
+++ b/backend-SpringBoot/BabyGuardianBackend/sensor-service/src/main/resources/application.properties
@@ -27,6 +27,19 @@ app.mqtt.clientId=vitals-${random.value}
 app.mqtt.topic=iot/vitals/+,iot/vitals/+/realtime,iot/status/+
 app.mqtt.qos=1
 app.mqtt.cleanSession=true
+app.mqtt.clean.publish=false
+app.mqtt.topic.clean.prefix=iot/vitals/clean/
+
+# cleaning rules
+app.cleaning.tempMin=0
+app.cleaning.tempMax=60
+app.cleaning.hrMin=0
+app.cleaning.hrMax=250
+app.cleaning.spo2Min=0
+app.cleaning.spo2Max=100
+
+# comportement: REJECT ou CLAMP
+app.cleaning.mode=TEST
 
 logging.level.org.eclipse.paho.client.mqttv3=INFO
 logging.level.org.springframework.integration.mqtt=INFO
@@ -36,3 +49,12 @@ monitoring.device-timeout-seconds=30
 
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8080/realms/babyGuardian-realm
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:8080/realms/babyGuardian-realm/protocol/openid-connect/certs
+
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer 
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.consumer.group-id=sensor-service-group
+spring.kafka.consumer.auto-offset-reset=earliest
+app.kafka.topic.vitals-cleaned=iot.vitals.cleaned


### PR DESCRIPTION
J’ai mis en place dans sensor-service une chaîne complète MQTT → nettoyage/validation des vitals → sauvegarde en base → publication des mesures nettoyées sur Kafka pour que les autres microservices puissent les consommer et déclencher des alertes.